### PR TITLE
fix exclude_host_filters not working

### DIFF
--- a/lib/ansible/plugins/inventory/azure_rm.py
+++ b/lib/ansible/plugins/inventory/azure_rm.py
@@ -348,7 +348,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     # FUTURE: fix underlying inventory stuff to allow us to quickly access known groupvars from reconciled host
     def _filter_host(self, inventory_hostname, hostvars):
-        self.templar.available_variables = hostvars
+        self.templar.set_available_variables(hostvars)
 
         for condition in self._filters:
             # FUTURE: should warn/fail if conditional doesn't return True or False


### PR DESCRIPTION
Fix for exclude_host_filters not being evaluated (also default_host_filters not being applied) for a bad assignment

##### SUMMARY
The variable assignment of self.templar led to an empty object.

If `fail_on_template_errors` is set to `False` the filter conditions are not evaluated, if let to the default `True` value an exception is raised:

```txt
Error evaluating filter condition 'location in ['westeurope']' for host server_6855: 'location' is undefined 
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible/plugins/inventory/azure_rm.py

##### ADDITIONAL INFORMATION

Ansible installed via pip3
```txt
ansible 2.8.0
  config file = /Users/blacksd/Documents/Repositories/operation-provisioning/ansible/ansible.cfg
  configured module search path = ['/Users/blacksd/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.7.3 (default, Mar 27 2019, 09:23:15) [Clang 10.0.1 (clang-1001.0.46.3)]
```

`azure_rm.py` taken from `devel`